### PR TITLE
Resolving issues involving loading configuration via Json

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,105 @@ Following an example of the configuration file.
 </Folder>
 ```
 
+
+```json
+{
+    "Name": "Root",
+    "Folders": [
+        {
+            "Name": "Folder",
+            "Folders": [
+                {
+                    "Name": "Datasources",
+                    "Hidden": "true",
+                    "DataSources": [
+                        {
+                            "ConnectionString": "Data Source={{Server}}\\{{Instance}};Initial Catalog=MyDB",
+                            "Name": "MyDB",
+                            "Extension": "SQL",
+                            "CredentialRetrieval": "Integrated"
+                        },
+                        {
+                            "ConnectionString": "Data Source={{Server}};Initial Catalog=MetaData",
+                            "Name": "MetaData",
+                            "Extension": "SQL",
+                            "CredentialRetrieval": "Store",
+                            "UserName": "user",
+                            "Password": "password",
+                            "WindowsCredentials": "True"
+                        }
+                    ]
+                },
+                {
+                    "Name": "Admin Reports",
+                    "Hidden": "true",
+                    "Reports": [
+                        {
+                            "Name": "Error Report",
+                            "Hidden": "true",
+                            "FileName": "Error Report.rdl"
+                        },
+                        {
+                            "Name": "Error Report for Export",
+                            "Hidden": "true",
+                            "FileName": "Error Report for Export.rdl"
+                        }
+                    ],
+                    "Security": [
+                        {
+                            "Name": "Administrator",
+                            "Roles": [
+                                "Browser",
+                                "Content Manager"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "Name": "User Reports",
+                    "Reports": [
+                        {
+                            "Name": "Users report",
+                            "Hidden": "false",
+                            "FileName": "UserReport.rdl"
+                        }
+                    ],
+                    "Folders": [
+                        {
+                            "Name": "Reports",
+                            "Hidden": "false",
+                            "Reports": [
+                                {
+                                    "Name": "Other report",
+                                    "Hidden": "false",
+                                    "FileName": "OtherReport.rdl"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "Security": [
+        {
+            "Name": "Users",
+            "Roles": [
+                "Browser"
+            ]
+        },
+        {
+            "Name": "Administrator",
+            "Roles": [
+                "Browser",
+                "Content Manager"
+            ]
+        }
+    ]
+}
+```
+
+
 Values that you see in double curly braces are placeholders that are going to be substituted in the release just before the deployment.
 
 Following is an example of how will this configuration file translate in SSRS.

--- a/examples/ReportConfiguration.json
+++ b/examples/ReportConfiguration.json
@@ -1,0 +1,94 @@
+{
+    "Name": "Root",
+    "Folders": [
+        {
+            "Name": "Folder",
+            "Folders": [
+                {
+                    "Name": "Datasources",
+                    "Hidden": "true",
+                    "DataSources": [
+                        {
+                            "ConnectionString": "Data Source={{Server}}\\{{Instance}};Initial Catalog=MyDB",
+                            "Name": "MyDB",
+                            "Extension": "SQL",
+                            "CredentialRetrieval": "Integrated"
+                        },
+                        {
+                            "ConnectionString": "Data Source={{Server}};Initial Catalog=MetaData",
+                            "Name": "MetaData",
+                            "Extension": "SQL",
+                            "CredentialRetrieval": "Store",
+                            "UserName": "user",
+                            "Password": "password",
+                            "WindowsCredentials": "True"
+                        }
+                    ]
+                },
+                {
+                    "Name": "Admin Reports",
+                    "Hidden": "true",
+                    "Reports": [
+                        {
+                            "Name": "Error Report",
+                            "Hidden": "true",
+                            "FileName": "Error Report.rdl"
+                        },
+                        {
+                            "Name": "Error Report for Export",
+                            "Hidden": "true",
+                            "FileName": "Error Report for Export.rdl"
+                        }
+                    ],
+                    "Security": [
+                        {
+                            "Name": "Administrator",
+                            "Roles": [
+                                "Browser",
+                                "Content Manager"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "Name": "User Reports",
+                    "Reports": [
+                        {
+                            "Name": "Users report",
+                            "Hidden": "false",
+                            "FileName": "UserReport.rdl"
+                        }
+                    ],
+                    "Folders": [
+                        {
+                            "Name": "Reports",
+                            "Hidden": "false",
+                            "Reports": [
+                                {
+                                    "Name": "Other report",
+                                    "Hidden": "false",
+                                    "FileName": "OtherReport.rdl"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "Security": [
+        {
+            "Name": "Users",
+            "Roles": [
+                "Browser"
+            ]
+        },
+        {
+            "Name": "Administrator",
+            "Roles": [
+                "Browser",
+                "Content Manager"
+            ]
+        }
+    ]
+}

--- a/examples/ReportConfiguration.json
+++ b/examples/ReportConfiguration.json
@@ -6,7 +6,7 @@
             "Folders": [
                 {
                     "Name": "Datasources",
-                    "Hidden": "true",
+                    "Hidden": true,
                     "DataSources": [
                         {
                             "ConnectionString": "Data Source={{Server}}\\{{Instance}};Initial Catalog=MyDB",
@@ -21,22 +21,22 @@
                             "CredentialRetrieval": "Store",
                             "UserName": "user",
                             "Password": "password",
-                            "WindowsCredentials": "True"
+                            "WindowsCredentials": true
                         }
                     ]
                 },
                 {
                     "Name": "Admin Reports",
-                    "Hidden": "true",
+                    "Hidden": true,
                     "Reports": [
                         {
                             "Name": "Error Report",
-                            "Hidden": "true",
+                            "Hidden": true,
                             "FileName": "Error Report.rdl"
                         },
                         {
                             "Name": "Error Report for Export",
-                            "Hidden": "true",
+                            "Hidden": true,
                             "FileName": "Error Report for Export.rdl"
                         }
                     ],
@@ -55,18 +55,18 @@
                     "Reports": [
                         {
                             "Name": "Users report",
-                            "Hidden": "false",
+                            "Hidden": false,
                             "FileName": "UserReport.rdl"
                         }
                     ],
                     "Folders": [
                         {
                             "Name": "Reports",
-                            "Hidden": "false",
+                            "Hidden": false,
                             "Reports": [
                                 {
                                     "Name": "Other report",
-                                    "Hidden": "false",
+                                    "Hidden": false,
                                     "FileName": "OtherReport.rdl"
                                 }
                             ]

--- a/task/ps_modules/ssrs.psm1
+++ b/task/ps_modules/ssrs.psm1
@@ -499,7 +499,7 @@ function GetJsonFolderItems($Folder, [Folder]$Parent = $null)
 
     foreach($dataSet in $folder.dataSets)
     {
-        $ds = [DataSet]::new($dataSet.name, $dataSet.fileName, $dataSet.inheritParentSecurity, $dataSet.hidden)
+        $ds = [DataSet]::new($dataSet.name, $dataSet.fileName, $dataSet.inheritParentSecurity, [System.Convert]::ToBoolean($dataSet.hidden))
 
         foreach($group in $dataSet.security)
         {
@@ -511,7 +511,7 @@ function GetJsonFolderItems($Folder, [Folder]$Parent = $null)
 
     foreach($report in $folder.reports)
     {
-        $r = [Report]::new($report.name, $report.fileName, $report.inheritParentSecurity, $report.hidden)
+        $r = [Report]::new($report.name, $report.fileName, $report.inheritParentSecurity, [System.Convert]::ToBoolean($report.hidden))
 
         foreach($group in $report.security)
         {

--- a/task/ps_modules/ssrs.psm1
+++ b/task/ps_modules/ssrs.psm1
@@ -499,7 +499,7 @@ function GetJsonFolderItems($Folder, [Folder]$Parent = $null)
 
     foreach($dataSet in $folder.dataSets)
     {
-        $ds += [DataSet]::new($dataSet.name, $dataSet.fileName, $dataSet.inheritParentSecurity, $dataSet.hidden)
+        $ds = [DataSet]::new($dataSet.name, $dataSet.fileName, $dataSet.inheritParentSecurity, $dataSet.hidden)
 
         foreach($group in $dataSet.security)
         {
@@ -511,7 +511,7 @@ function GetJsonFolderItems($Folder, [Folder]$Parent = $null)
 
     foreach($report in $folder.reports)
     {
-        $r += [Report]::new($report.name, $report.fileName, $report.inheritParentSecurity, $report.hidden)
+        $r = [Report]::new($report.name, $report.fileName, $report.inheritParentSecurity, $report.hidden)
 
         foreach($group in $report.security)
         {

--- a/task/ps_modules/ssrs.psm1
+++ b/task/ps_modules/ssrs.psm1
@@ -469,7 +469,7 @@ function Set-SecurityPolicy()
 
 function GetJsonFolderItems($Folder, [Folder]$Parent = $null)
 {
-    $f = [Folder]::new($folder.name, $Parent, $folder.hidden)
+    $f = [Folder]::new($folder.name, $Parent, [System.Convert]::ToBoolean($folder.inheritParentSecurity), [System.Convert]::ToBoolean($folder.hidden))
 
     foreach($group in $folder.security)
     {

--- a/task/ps_modules/ssrs.psm1
+++ b/task/ps_modules/ssrs.psm1
@@ -469,7 +469,7 @@ function Set-SecurityPolicy()
 
 function GetJsonFolderItems($Folder, [Folder]$Parent = $null)
 {
-    $f = [Folder]::new($folder.name, $Parent, [System.Convert]::ToBoolean($folder.inheritParentSecurity), [System.Convert]::ToBoolean($folder.hidden))
+    $f = [Folder]::new($folder.name, $Parent, $folder.inheritParentSecurity, $folder.hidden)
 
     foreach($group in $folder.security)
     {
@@ -499,7 +499,7 @@ function GetJsonFolderItems($Folder, [Folder]$Parent = $null)
 
     foreach($dataSet in $folder.dataSets)
     {
-        $ds = [DataSet]::new($dataSet.name, $dataSet.fileName, $dataSet.inheritParentSecurity, [System.Convert]::ToBoolean($dataSet.hidden))
+        $ds = [DataSet]::new($dataSet.name, $dataSet.fileName, $dataSet.inheritParentSecurity, $dataSet.hidden)
 
         foreach($group in $dataSet.security)
         {
@@ -511,7 +511,7 @@ function GetJsonFolderItems($Folder, [Folder]$Parent = $null)
 
     foreach($report in $folder.reports)
     {
-        $r = [Report]::new($report.name, $report.fileName, $report.inheritParentSecurity, [System.Convert]::ToBoolean($report.hidden))
+        $r = [Report]::new($report.name, $report.fileName, $report.inheritParentSecurity, $report.hidden)
 
         foreach($group in $report.security)
         {


### PR DESCRIPTION
[Folder]:new() doesn't have a 3 parameter overload, assume it was refactored and not tested with the JSON Version

Two calls to the += operator were not valid and did not appear to be needed.

Converted the true/false to boolean just like the GetXmlFolderItems method.

Added a Json version of the example ReportConfiguration file