### PR TITLE
Clean folders on deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Aside of the path itself, you can specify the permissions for both folders that 
 
 Folders and the inside objects are listed in the configuration file as hierarchical tree structure.
 
+Folders may be cleaned up to remove old or renamed reports during the deployment by specifying the CleanExistingItems configuration property on the folder configuration.
+
 Following an example of the configuration file.
 
 ```xml
@@ -46,7 +48,7 @@ Following an example of the configuration file.
             <DataSource ConnectionString="Data Source={{Server}};Initial Catalog=MetaData" Name="MetaData" Extension="SQL" CredentialRetrieval="Store" UserName="user" Password="password" WindowsCredentials="True" />
           </DataSources>
         </Folder>
-        <Folder Name="Admin Reports" Hidden="true">
+        <Folder Name="Admin Reports" Hidden="true" CleanExistingItems="true">
           <Reports>
             <Report Name="Error Report" Hidden="true" FileName="Error Report.rdl" />
             <Report Name="Error Report for Export" Hidden="true" FileName="Error Report for Export.rdl" />
@@ -60,7 +62,7 @@ Following an example of the configuration file.
             </Security>
           </Security>
         </Folder>
-        <Folder Name="User Reports">>
+        <Folder Name="User Reports">
           <Reports>
             <Report Name="Users report" Hidden="false" FileName="UserReport.rdl" />
           </Reports>
@@ -121,6 +123,7 @@ Following an example of the configuration file.
                 {
                     "Name": "Admin Reports",
                     "Hidden": true,
+                    "CleanExistingItems": true,
                     "Reports": [
                         {
                             "Name": "Error Report",

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Aside of the path itself, you can specify the permissions for both folders that 
 
 Folders and the inside objects are listed in the configuration file as hierarchical tree structure.
 
-Folders may be cleaned up to remove old or renamed reports during the deployment by specifying the CleanExistingItems configuration property on the folder configuration.
+Folders may be cleaned up to remove old or renamed reports during the deployment by specifying the CleanExistingItems configuration property on the folder configuration. 
+Note: The CleanExistingItems config property will only delete files when cleaning a folder and will preserve any existing subfolders under the current directory.
 
 Following an example of the configuration file.
 

--- a/examples/ReportConfiguration.json
+++ b/examples/ReportConfiguration.json
@@ -6,6 +6,7 @@
             "Folders": [
                 {
                     "Name": "Datasources",
+                    "CleanExistingItems": true,
                     "Hidden": true,
                     "DataSources": [
                         {

--- a/examples/ReportConfiguration.xml
+++ b/examples/ReportConfiguration.xml
@@ -4,7 +4,7 @@
   <Folders>
     <Folder Name="Folder">
       <Folders>
-        <Folder Name="Datasources" Hidden="true">
+        <Folder Name="Datasources" Hidden="true" CleanExistingItems="true">
           <DataSources>
             <DataSource ConnectionString="Data Source={{Server}}\{{Instance}};Initial Catalog=MyDB" Name="MyDB" Extension="SQL" CredentialRetrieval="Integrated" />
             <DataSource ConnectionString="Data Source={{Server}};Initial Catalog=MetaData" Name="MetaData" Extension="SQL" CredentialRetrieval="Store" UserName="user" Password="password" WindowsCredentials="True" />

--- a/task/ps_modules/ssrs.psm1
+++ b/task/ps_modules/ssrs.psm1
@@ -206,47 +206,6 @@ function Publish-SsrsFolder()
             Write-Verbose "Current folder is the root folder"
         }
         
-        Set-SecurityPolicy -Proxy $Proxy -Folder $currentFolder -RoleAssignments $Folder.RoleAssignments -InheritParentSecurity:$Folder.InheritParentSecurity -Overwrite
-
-        foreach($folder in $Folder.Folders)
-        {
-            Publish-SsrsFolder -Folder $folder -Proxy $Proxy -FilesFolder $FilesFolder -Overwrite:$Overwrite
-        }
-    }
-    END { }
-}
-
-
-function Clear-SsrsFolderItems()
-{
-    [CmdletBinding()]
-    param
-    (
-        [Folder][parameter(Mandatory = $true)]$Folder,
-        [System.Web.Services.Protocols.SoapHttpClientProtocol][parameter(Mandatory = $true)]$Proxy
-    )
-    BEGIN
-    {
-        Write-Verbose "Entering script $($MyInvocation.MyCommand.Name)"
-        Write-Verbose "Parameter Values"
-        $PSBoundParameters.Keys | ForEach-Object { Write-Verbose "$_ = '$($PSBoundParameters[$_])'" }    
-    }
-    PROCESS
-    {
-        foreach($subFolder in $Folder.Folders)
-        {
-            Clear-SsrsFolderItems -Folder $subFolder -Proxy $proxy
-        }
-
-        if ($Folder.Parent)
-        {
-            $currentFolder = "$($Folder.Path().TrimEnd('/'))/$($Folder.Name)"
-        }
-        else
-        {
-            $currentFolder = "/"
-        }
-
         if($Folder.CleanExistingItems -eq $true){
 
             Write-Verbose "Clean existing files from folder $($currentFolder)"
@@ -258,6 +217,13 @@ function Clear-SsrsFolderItems()
                     $Proxy.DeleteItem($catalogItem.Path)
                 }
             }
+        }
+
+        Set-SecurityPolicy -Proxy $Proxy -Folder $currentFolder -RoleAssignments $Folder.RoleAssignments -InheritParentSecurity:$Folder.InheritParentSecurity -Overwrite
+
+        foreach($folder in $Folder.Folders)
+        {
+            Publish-SsrsFolder -Folder $folder -Proxy $Proxy -FilesFolder $FilesFolder -Overwrite:$Overwrite
         }
     }
     END { }

--- a/task/task.ps1
+++ b/task/task.ps1
@@ -44,7 +44,7 @@ try
     {
         throw "Provided configuration file path $ssrsFilePath is not valid."
     }
-
+    Clear-SsrsFolderItems -Folder $folder -Proxy $proxy
     Publish-SsrsFolder -Folder $folder -Proxy $proxy -FilesFolder $rdlFilesFolder -Overwrite:$overwrite
     $dataSources = Publish-DataSource -Folder $folder -Proxy $proxy -Overwrite:$overwrite
     $dataSets = Publish-DataSet -Folder $folder -Proxy $proxy -FilesFolder $rdlFilesFolder -Overwrite:$overwrite

--- a/task/task.ps1
+++ b/task/task.ps1
@@ -44,7 +44,6 @@ try
     {
         throw "Provided configuration file path $ssrsFilePath is not valid."
     }
-    Clear-SsrsFolderItems -Folder $folder -Proxy $proxy
     Publish-SsrsFolder -Folder $folder -Proxy $proxy -FilesFolder $rdlFilesFolder -Overwrite:$overwrite
     $dataSources = Publish-DataSource -Folder $folder -Proxy $proxy -Overwrite:$overwrite
     $dataSets = Publish-DataSet -Folder $folder -Proxy $proxy -FilesFolder $rdlFilesFolder -Overwrite:$overwrite


### PR DESCRIPTION
This change adds a configuration property named CleanExistingItems to the folder object.
If this is set to true for a particular folder in the config file the task will remove all items in the folder with the exception of sub folders.
This makes it easier to keep SSRS in sync with whats in source control if RDL's are being removed or renamed during development.

Addresses issue #37