### PR TITLE
Use reference instead of name while referencing DataSet and DataSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Different parameters of the task are explained below:
 * **Report Files Path**: Path of the folder containing RDL and/or RSD files or on a UNC path like, `\\BudgetIT\Web\Deploy\`. The UNC path should be accessible to the machine's administrator account. Environment variables are also supported, like `$env:windir`, `$env:systemroot`, `$env:windir\FabrikamFibre\DB`. Wildcards can be used. For example, `**/*.rdl` for RDL files present in all sub folders.
 * **SSRS configuration file**: Location of the XML or JSON configuration file.
 * **SSIS folder Name**: Folder name in the SSIS Package Store.
-* **Reference DataSources**: If selected the DataSources in the configuration file will be referenced in the Reports, by matching the DataSource name.
-* **Reference DataSets**: If selected the DataSets in the configuration file will be referenced in the Reports, by matching the DataSets name.
+* **Reference DataSources**: If selected the DataSources in the configuration file will be referenced in the Reports, by matching the DataSource DataSourceReference value.
+* **Reference DataSets**: If selected the DataSets in the configuration file will be referenced in the Reports, by matching the DataSets SharedDataSetReference value.
 * **Overwrite existing objects**: If selected overwrites objects in the same path that already do exists.
 
 ## Example of the configuration file

--- a/task/ps_modules/ssrs.psm1
+++ b/task/ps_modules/ssrs.psm1
@@ -962,21 +962,21 @@ function New-SsrsReport()
 
             if ($ReferenceDataSources -and $Datasources)
             {
-                $nodes = $Definition.SelectNodes('d:Report/d:DataSources/d:DataSource/d:DataSourceReference/..', $NsMgr)
+                $nodes = $Definition.SelectNodes('d:Report/d:DataSources/d:DataSource/d:DataSourceReference', $NsMgr)
 
                 foreach ($node in $nodes)
                 {
-                    $Datasources | Where-Object { $_.Name -eq $node.Name } | ForEach-Object { $node.DataSourceReference = $_.Path.ToString() ; $node.ChildNodes[2].InnerText = $_.Id }
+                    $Datasources | Where-Object { $_.Name -eq $node.InnerText } | ForEach-Object { $node.InnerText = $_.Path.ToString() ; $node.ParentNode.ChildNodes[2].InnerText = $_.Id }
                 }
             }
 
             if ($ReferenceDataSets -and $DataSets)
             {
-                $nodes = $Definition.SelectNodes('d:Report/d:DataSets/d:DataSet/d:SharedDataSet/d:SharedDataSetReference/..', $NsMgr)
+                $nodes = $Definition.SelectNodes('d:Report/d:DataSets/d:DataSet/d:SharedDataSet/d:SharedDataSetReference', $NsMgr)
 
                 foreach($node in $nodes)
                 {
-                    @($Datasets | Where-Object { $_.Name -eq $node.ParentNode.Name }) | ForEach-Object { $node.SharedDataSetReference = $_.Path }
+                    @($Datasets | Where-Object { $_.Name -eq $node.InnerText }) | ForEach-Object { $node.InnerText = $_.Path }
                 }
             }
 

--- a/task/task.json
+++ b/task/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": "3",
     "Minor": "1",
-    "Patch": "6"
+    "Patch": "7"
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "Deploy reports",
@@ -92,7 +92,7 @@
     {
       "groupName": "deploy",
       "defaultValue": "true",
-      "helpMarkDown": "If selected the DataSources in the configuration file will be referenced in the Reports, by matching the DataSource name.",
+      "helpMarkDown": "If selected the DataSources in the configuration file will be referenced in the Reports, by matching the DataSource DataSourceReference value.",
       "label": "Reference DataSources",
       "name": "referenceDataSources",
       "required": false,
@@ -101,7 +101,7 @@
     {
       "groupName": "deploy",
       "defaultValue": "true",
-      "helpMarkDown": "If selected the DataSets in the configuration file will be referenced in the Reports, by matching the DataSets name.",
+      "helpMarkDown": "If selected the DataSets in the configuration file will be referenced in the Reports, by matching the DataSets SharedDataSetReference value.",
       "label": "Reference DataSets",
       "name": "referenceDataSets",
       "required": false,


### PR DESCRIPTION
fixes #28 

Tested locally on Azure DevOps Server 2019.1.1 (17.153.29522.3) and SSRS 2017 (Version 14.0.600.460 (October 2017))
In my test, my DataSource has the same name of all its references.