### PR TITLE
Default value for server input changed

### DIFF
--- a/task/task.json
+++ b/task/task.json
@@ -36,7 +36,7 @@
       "name": "url",
       "type": "string",
       "label": "ReportService2010 endpoint URL",
-      "defaultValue": "http://your.server/ReportServer/ReportService2010.asmx?wsdl",
+      "defaultValue": "http://your.server/ReportServer/ReportService2010.asmx",
       "required": true,
       "helpMarkDown": "The Report Server Web service ReportService2010 endpoint URL"
     },


### PR DESCRIPTION
The previous given default is not working with the code. The code checks for the .asmx ending of the URL and appends the default endpoint ReportService2010.asmx if needed. The URL ending with ?wsdl resulted in an improper append of /ReportService2010.asmx which will not work at all.