### PR TITLE
Use reference instead of name while setting DataSet and DataSource item reference with SetItemReferences

### DIFF
--- a/task/task.json
+++ b/task/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": "3",
     "Minor": "1",
-    "Patch": "10"
+    "Patch": "11"
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "Deploy reports",


### PR DESCRIPTION
fixes #69 and complete #52 

I've added the @muad81's solution for references already containing a path.