### PR TITLE
Preserve xml indenting and carriage return in final rdl file

### DIFF
--- a/task/ps_modules/ssrs.psm1
+++ b/task/ps_modules/ssrs.psm1
@@ -985,7 +985,13 @@ function New-SsrsReport()
                 }
             }
 
-            $rawDefinition = [System.Text.Encoding]::UTF8.GetBytes($Definition.OuterXml)
+            # To preserve carriage return and indenting in xml file use xml text writer
+            #$rawDefinition = [System.Text.Encoding]::UTF8.GetBytes($Definition.OuterXml)
+            $stringWriter = New-Object System.IO.StringWriter
+            $xmlWriter = New-Object System.Xml.XmlTextWriter($stringWriter)
+            $xmlWriter.Formatting = [System.Xml.Formatting]::Indented
+            $Definition.WriteContentTo($xmlWriter)
+            $rawDefinition = [System.Text.Encoding]::UTF8.GetBytes($stringWriter.ToString())
 
             Write-Verbose "Creating report $Name"
             $warnings = $null


### PR DESCRIPTION
Rdl file is getting deployed without carriage return and indenting. New-SsrsReport() function in ssrs.pms1 file performs some manipulation on xmldocument object which ends up loosing formatting in xml file and prints entire xml content in single line in final rdl file.

Attached is the code fix to resolve this issue. Could you please review PR and merge the changes to git repo?